### PR TITLE
Add header to searchLocationReverse (#458)

### DIFF
--- a/web/src/lib/stores/search_store.ts
+++ b/web/src/lib/stores/search_store.ts
@@ -131,6 +131,9 @@ export async function searchLocationReverse(lat: number, lon: number) {
     const nominatimURL = env.PUBLIC_NOMINATIM_URL ?? "https://nominatim.openstreetmap.org"
     const r = await fetch(`${nominatimURL}/reverse?lat=${lat}&lon=${lon}&format=geojson&addressdetails=1`, {
         method: "GET",
+        headers: new Headers({
+            "User-Agent": "wanderer/" + version
+        })
     });
     if (!r.ok) {
         const response = await r.json();


### PR DESCRIPTION
As described in #458, uploading trails intermittently fails because the request to the Nominatim API in `searchLocationReverse` does not contain a header as required by the API. The header was added to `searchLocations` in 47f431e, but the issue with the trail upload was caused by it missing in `searchLocationReverse`. This PR adds it there as well.